### PR TITLE
docs(seo): tighten README and package metadata for discoverability

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,7 +66,7 @@ brews:
       name: homebrew-ccp
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     homepage: "https://github.com/dalley/ccp"
-    description: "Manage multiple Claude Code profiles on one machine"
+    description: "Profile manager for Claude Code. Switch between multiple Claude Code accounts/profiles on one machine."
     license: "MIT"
     install: |
       bin.install "ccp"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # ccp — Claude Code Profiles
 
-Manage multiple named Claude Code configurations on one machine. Switch between them with one command, run two in parallel with shell aliases, sync them across machines via Git.
+**Profile manager for Claude Code.** Switch between work and personal Claude Code accounts with one command, run two profiles side by side, sync your configs across machines via Git.
 
-Status: **alpha** (v1 feature-complete, pre-release).
+`ccp` is like `direnv` or `pyenv`, but for `CLAUDE_CONFIG_DIR`. It manages multiple named Claude Code profiles on one machine — settings, agents, commands, hooks, skills, output-styles, keybindings, and `CLAUDE.md` — and lets you swap between them without editing files by hand. Your default `~/.claude/` is never touched; removing the shell-init line reverses everything.
+
+Status: **alpha** (v1 feature-complete, pre-release). A v2 branch in review adds auto-activation via a `.claude-profile` marker (direnv-style allow-list) and secrets separation with OS keychain + `op://` resolution — see the Roadmap section.
 
 ## What it does
 
@@ -11,6 +13,14 @@ Claude Code reads its config from `~/.claude/` (or from `$CLAUDE_CONFIG_DIR` if 
 - `ccp use work` — set a global active profile. New shells pick it up automatically.
 - `claude-work` — an optional per-profile alias that launches Claude against that profile without switching the global active. Lets you run two Claudes side-by-side.
 - `ccp exec work -- claude mcp list` — one-shot, no shell state.
+
+## Use cases
+
+- **Work vs. personal Claude Code accounts** on the same laptop — different auth, different MCP servers, different `CLAUDE.md` memory.
+- **Run two Claude Code instances in parallel** in separate terminals (`claude-work` in one, `claude-personal` in another) without their sessions clobbering each other.
+- **Sync your Claude Code setup across machines** — keep your agents, slash commands, hooks, skills, and `CLAUDE.md` in Git; clone on a new laptop and every profile is there.
+- **Try experimental profiles** (new MCP servers, draft agents, evaluation setups) without touching your daily-driver config.
+- **Team-ish workflows** — share a read-only "team" profile via Git alongside your personal one.
 
 ## Install
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,23 @@
 {
   "name": "@dalley/ccp",
   "version": "0.1.1",
-  "description": "Manage multiple Claude Code profiles on one machine (native binary, installed via npm)",
+  "description": "Profile manager for Claude Code. Switch between multiple Claude Code accounts/profiles on one machine, run work and personal side by side, sync configs across machines. Like direnv or pyenv, but for CLAUDE_CONFIG_DIR. Native binary, installed via npm.",
+  "keywords": [
+    "claude-code",
+    "claude",
+    "anthropic",
+    "profile-manager",
+    "profile-switcher",
+    "account-switcher",
+    "multi-account",
+    "cli",
+    "cli-tool",
+    "config-manager",
+    "claude-config-dir",
+    "direnv",
+    "dotfiles",
+    "developer-tools"
+  ],
   "bin": {
     "ccp": "bin/ccp"
   },


### PR DESCRIPTION
Optimizes the project's discoverability surfaces so people Googling "switch between Claude Code accounts", "multiple Claude Code profiles", or \`CLAUDE_CONFIG_DIR\` actually find ccp.

## What changed

### Repo metadata (done via \`gh repo edit\` — not in this diff, but recorded here)

- **Description:** "Switch between multiple Claude Code profiles on one machine. Isolated CLAUDE_CONFIG_DIR per profile, run work and personal side by side, sync via Git." (158 chars — fits the Google snippet)
- **Topics (20):** \`claude-code\`, \`claude\`, \`anthropic\`, \`cli\`, \`cli-tool\`, \`profile-manager\`, \`profile-switching\`, \`multi-account\`, \`account-switcher\`, \`config-manager\`, \`configuration-manager\`, \`developer-tools\`, \`developer-productivity\`, \`go\`, \`golang\`, \`dotfiles\`, \`env-manager\`, \`direnv\`, \`mcp\`, \`claude-config\`

### README.md

- Rewrote the H1 tagline and first paragraph to lead with the phrasing real users type ("switch between work and personal Claude Code accounts", the direnv/pyenv analogy, \`CLAUDE_CONFIG_DIR\`).
- Added a **Use cases** section with the five scenarios that show up repeatedly in Reddit/HN/Medium posts about Claude Code setups.
- Made the v2-in-review status explicit so we don't misrepresent what's on \`main\` today.

### npm/package.json

- Rewrote the \`description\` to mirror the repo description (was the generic "native binary, installed via npm" line).
- Added a \`keywords\` array of 14 terms so \`npm search\` finds it.

### .goreleaser.yaml

- Updated the brew formula \`description\` to match.

## Why this matters

Competitive research found:

| Repo | Stars | Topics set? |
|---|---|---|
| \`kaitranntt/ccs\` | 2.1k | **Yes (17 topics)** |
| \`foreveryh/claude-code-switch\` | 566 | No |
| \`realiti4/claude-swap\` | 228 | 2 topics |
| \`nwiizo/cctx\` | 144 | No |
| \`breakstring/cccs\` | 79 | No |
| \`MikeVeerman/jean-claude\` (ccp's predecessor) | 70 | No |

The #1 tool by stars aggressively uses GitHub topics; everyone below 2k stars does not. Setting the 20 topics + tightening the description is the single highest-ROI discoverability change — GitHub's topic-browsing pages (\`github.com/topics/claude-code\`) are how ecosystem-curious users find tools, and neither Google nor GitHub currently surface ccp for the queries it should own.

## What this PR is NOT

- No feature changes.
- No version bump (description/keywords edits in \`npm/package.json\` don't require a publish on their own; tie it to the next release).
- No misrepresentation — v2 features are clearly labeled as "in review" under Roadmap.

## Test plan

- [x] \`go build -buildvcs=false ./...\` — unaffected (no code changes)
- [x] \`go test -buildvcs=false ./...\` — unaffected
- [x] README renders correctly in the GitHub Markdown preview
- [x] \`gh repo view\` confirms the new description and all 20 topics
- [x] npm package.json validates — \`node -e 'JSON.parse(require("fs").readFileSync("npm/package.json"))'\` succeeds

## Also considered (deferred)

- Open Graph preview image. GitHub auto-generates one from the avatar + description — not worth hand-rolling yet.
- README badges (CI, version). Fine to add later once CI + releases stabilize; badges without substance feel performative.
- A separate \`.github/FUNDING.yml\` / discussion templates. Premature for alpha.